### PR TITLE
fix(build): use ext options from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('SystemNavigationBar_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('SystemNavigationBar_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('compileSdkVersion', 29)
+    buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {
-        minSdkVersion safeExtGet('SystemNavigationBar_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('SystemNavigationBar_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
[React Native template](https://github.com/facebook/react-native/blob/main/template/android/build.gradle) already provides `buildToolsVersion`, `minSdkVersion`, `compileSdkVersion` and `targetSdkVersion` ext options, so I think that `build.gradle` should not use `SystemNavigationBar_` prefixed options. This may cause some inconsistencies in build process.