### PR TITLE
fix: race condition when checking current activity

### DIFF
--- a/android/src/main/java/com/reactnativesystemnavigationbar/SystemNavigationBarModule.java
+++ b/android/src/main/java/com/reactnativesystemnavigationbar/SystemNavigationBarModule.java
@@ -2,6 +2,7 @@ package com.reactnativesystemnavigationbar;
 
 import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
+import android.app.Activity;
 import android.os.Build;
 import android.view.View;
 import android.view.Window;
@@ -146,11 +147,12 @@ public class SystemNavigationBarModule extends ReactContextBaseJavaModule {
         promise.reject("Error: ", "false");
         return;
       }
-      if (getCurrentActivity() == null) {
+      final Activity currentActivity = getCurrentActivity();
+      if (currentActivity == null) {
         promise.reject("Error: ", "false");
         return;
       }
-      final Window view = getCurrentActivity().getWindow();
+      final Window view = currentActivity.getWindow();
 
       runOnUiThread(
         () -> {
@@ -211,11 +213,12 @@ public class SystemNavigationBarModule extends ReactContextBaseJavaModule {
         promise.reject("Error: ", "false");
         return;
       }
-      if (getCurrentActivity() == null) {
+      final Activity currentActivity = getCurrentActivity();
+      if (currentActivity == null) {
         promise.reject("Error: ", "false");
         return;
       }
-      final Window view = getCurrentActivity().getWindow();
+      final Window view = currentActivity.getWindow();
       runOnUiThread(
         () -> {
           if (Build.VERSION.SDK_INT >= 28) {
@@ -247,11 +250,12 @@ public class SystemNavigationBarModule extends ReactContextBaseJavaModule {
         promise.reject("Error: ", "false");
         return;
       }
-      if (getCurrentActivity() == null) {
+      final Activity currentActivity = getCurrentActivity();
+      if (currentActivity == null) {
         promise.reject("Error: ", "false");
         return;
       }
-      final Window view = getCurrentActivity().getWindow();
+      final Window view = currentActivity.getWindow();
       runOnUiThread(
         () -> {
           if (Build.VERSION.SDK_INT >= 29) {
@@ -275,11 +279,12 @@ public class SystemNavigationBarModule extends ReactContextBaseJavaModule {
             promise.reject("Error: ", "false");
             return;
           }
-          if (getCurrentActivity() == null) {
+          Activity currentActivity = getCurrentActivity();
+          if (currentActivity == null) {
             promise.reject("Error: ", "false");
             return;
           }
-          View decorView = getCurrentActivity().getWindow().getDecorView();
+          View decorView = currentActivity.getWindow().getDecorView();
 
           decorView.setSystemUiVisibility(visibility);
         }


### PR DESCRIPTION
We were experiencing some crashes caused by the NullPointerException raised in the library in production.
```
java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.Window android.app.Activity.getWindow()' on a null object reference
    at com.reactnativesystemnavigationbar.SystemNavigationBarModule.setNavigationColor(SystemNavigationBarModule.java:1)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:18)
    at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:13)
    at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:1)
    at android.os.Looper.loopOnce(Looper.java:210)
    at android.os.Looper.loop(Looper.java:299)
    at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:8)
    at java.lang.Thread.run(Thread.java:920)
```

It appears that Activity was stopped before setNavigationColor call.
```
- ui.lifecycle {
  screen: MainActivity, 
  state: stopped
}
- ui.lifecycle {
  screen: MainActivity, 
  state: saveInstanceState
}
- NullPointerException: Attempt to invoke virtual method 'android.view.Window android.app.Activity.getWindow()' on a null object reference
```

There is an issue in the code below:
```
if (getCurrentActivity() == null) {
         promise.reject("Error: ", "false");
         return;
}
final Window view = getCurrentActivity().getWindow();
```

Because getCurrentActivity() result is not saved, current activity may be replaced by null after if condition worked, which is exactly what happens before the crash. For example,
Happy path: `App working -> setNavigationColor() -> app stops -> if getCurrentActivity() == null is true -> return`.
Edge case: `App working -> setNavigationColor() -> if getCurrentActivity() == null is FALSE -> app stops -> getCurrentActivity().getWindow() -> NPE`.

In the edge case NPE happens because app is already stopped, so that `getCurrentActivity()` returns `null` and then `getWindow()` is called on the null instance.

This PR saves `getCurrentActivity()` result into the variable, so that `Activity.getWindow()` never raises a NPE.