### PR TITLE
fix(set-navigation-color): call promise callback only once

### DIFF
--- a/android/src/main/java/com/reactnativesystemnavigationbar/SystemNavigationBarModule.java
+++ b/android/src/main/java/com/reactnativesystemnavigationbar/SystemNavigationBarModule.java
@@ -193,7 +193,7 @@ public class SystemNavigationBarModule extends ReactContextBaseJavaModule {
 
           if (modeStyle != NO_MODE) {
             Boolean isLight = modeStyle.equals(LIGHT);
-            setModeStyle(!isLight, bar, promise);
+            setModeStyle(!isLight, bar);
           }
         }
       );
@@ -308,26 +308,27 @@ public class SystemNavigationBarModule extends ReactContextBaseJavaModule {
     decorView.setSystemUiVisibility(bit);
   }
 
+  private void setModeStyle(Boolean light, Integer bar) {
+    if (Build.VERSION.SDK_INT >= 26) {
+      if (getCurrentActivity() == null) {
+        throw new IllegalViewOperationException("current activity is null");
+      }
+
+      if (bar.equals(NAVIGATION_BAR)) {
+        setBarStyle(light, View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+      } else if (bar.equals(STATUS_BAR)) {
+        setBarStyle(light, View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+      } else if (bar.equals(NAVIGATION_BAR_STATUS_BAR)) {
+        setBarStyle(light, View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+      }
+    }
+  }
   private void setModeStyle(Boolean light, Integer bar, Promise promise) {
     try {
       runOnUiThread(
         () -> {
-          if (Build.VERSION.SDK_INT >= 26) {
-            if (getCurrentActivity() == null) {
-              promise.reject("Error: ", "false");
-              return;
-            }
-
-            if (bar.equals(NAVIGATION_BAR)) {
-              setBarStyle(light, View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
-            } else if (bar.equals(STATUS_BAR)) {
-              setBarStyle(light, View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-            } else if (bar.equals(NAVIGATION_BAR_STATUS_BAR)) {
-              setBarStyle(light, View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-            }
-
-            promise.resolve("true");
-          }
+          setModeStyle(light, bar)
+          promise.resolve("true");
         }
       );
     } catch (IllegalViewOperationException e) {


### PR DESCRIPTION
Hello there. We are experiencing rare native crashes in `setNavigationColor` function:
```
java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.
    at com.facebook.react.bridge.CallbackImpl.invoke(CallbackImpl.java:4)
    at com.facebook.react.bridge.PromiseImpl.resolve(PromiseImpl.java:2)
    at com.reactnativesystemnavigationbar.SystemNavigationBarModule.lambda$setModeStyle$4(SystemNavigationBarModule.java:10)
    at com.reactnativesystemnavigationbar.SystemNavigationBarModule.c
    at aa.e.run
    at android.os.Handler.handleCallback(Handler.java:873)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:226)
    at android.app.ActivityThread.main(ActivityThread.java:7224)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:500)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:913)
``` 

This is probably caused by the `setModeStyle` internal call, because it accepts promise, so that when parent function has finished it calls `promise.resolve` second time. This is fixed by overloading `setModeStyle` without promise, so that we can call it from UI thread directly.