### PR TITLE
Add null checking to prevent setModeStyle crashes

### DIFF
--- a/android/src/main/java/com/reactnativesystemnavigationbar/SystemNavigationBarModule.java
+++ b/android/src/main/java/com/reactnativesystemnavigationbar/SystemNavigationBarModule.java
@@ -468,10 +468,15 @@ public class SystemNavigationBarModule extends ReactContextBaseJavaModule {
   }
 
   private void setModeStyle(Boolean light, Integer bar) {
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity == null) {
+      return;
+    }
+
     int visibility = 0;
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      WindowInsetsController insetsController = getCurrentActivity().getWindow().getInsetsController();
+      WindowInsetsController insetsController = currentActivity.getWindow().getInsetsController();
       int navigationBarAppearance = WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS;
       int statusBarAppearance = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS;
       int bothBarAppearance = statusBarAppearance | navigationBarAppearance;


### PR DESCRIPTION
Fixes https://github.com/kadiraydinli/react-native-system-navigation-bar/issues/59 where `currentActivity()` is called while the activity is null

Thanks [efstathiosntonas](https://github.com/efstathiosntonas) for the solution.